### PR TITLE
Europeana driver: include content from all themes

### DIFF
--- a/ajapaik/ajapaik/curator_drivers/europeana.py
+++ b/ajapaik/ajapaik/curator_drivers/europeana.py
@@ -146,7 +146,6 @@ class EuropeanaDriver(object):
                 'reusability': 'open',
                 'profile': 'portal',
                 'qf':'',
-                'theme': 'photography',
                 'query':cleaned_data['fullSearch'],
                 'rows':self.page_size,
                 'start':self.page_size*(cleaned_data['flickrPage']-1)+1


### PR DESCRIPTION
This change removes the Europeana curator drivers limit to only search contents in the Photography collection (in the API called theme). The Photography collection is for content related to the history of photography rather then photographs in general. 

Exemplified: the following is a search for "järnväg gotland" (Swedish for "railroad gotland"). The first URL is searching in all of Europeana while the second example is limited to the photography collection. As of December 2019 the first returns 14 results (11 relevant to Ajapaik) and the second one 0 results.

https://www.europeana.eu/portal/en/search?per_page=72&q=j%C3%A4rnv%C3%A4g+gotland&view=grid&f%5BTYPE%5D%5B%5D=IMAGE

https://www.europeana.eu/portal/en/collections/photography?q=j%C3%A4rnv%C3%A4g%20gotland&view=grid