### PR TITLE
lock allauth version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 cmake
 django-admin-tools
-django-allauth
+django-allauth==0.40.0
 django-autocomplete-light==2.3.3
 django-bootstrap-dynamic-formsets
 django-bootstrap4


### PR DESCRIPTION
Version 0.41.0 dropped Django 1.11 support: https://django-allauth.readthedocs.io/en/latest/release-notes.html#id1

(Startup crashes on 0.41.0 and later)