### PR TITLE
fixes a issue causing the map to disapear in photoview.html

### DIFF
--- a/ajapaik/ajapaik/static/css/ajp-style.css
+++ b/ajapaik/ajapaik/static/css/ajp-style.css
@@ -1194,6 +1194,7 @@ a.fullscreen {
 #ajp-photo-modal-map-canvas {
   height: calc(100% - 25px);
   max-height: 99%;
+  min-height: 300px;
   position: relative;
 }
 


### PR DESCRIPTION
When the photoview collapses the map it would disappear(get a hight of 0) while leaving buttons coordinates etc floating over prior elements.

This forces the map to never get a height below 300px thus not being able to disappear.

Before:
![Screenshot from 2021-06-08 13-51-44](https://user-images.githubusercontent.com/2631719/121180769-809ba900-c861-11eb-9b29-b4b234a56ded.png)

After:
![Screenshot from 2021-06-08 13-52-10](https://user-images.githubusercontent.com/2631719/121180767-80031280-c861-11eb-834f-ea87a363cd40.png)
